### PR TITLE
simpler environments; js tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nomic-ai/atlas",
-  "version": "0.1.6",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nomic-ai/atlas",
-      "version": "0.1.6",
+      "version": "0.3.0",
       "dependencies": {
         "apache-arrow": "^11.0.0",
         "dotenv": "^16.0.3",

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -67,7 +67,8 @@ export class AtlasProjection extends BaseAtlasClass {
   }
 
   get quadtree_root(): string {
-    return `https://${this.user.tenant.api_domain}/v1/project/public/${this.project_id}/index/projection/${this.id}/quadtree`;
+    // TODO: don't hardcode `public` here.
+    return `https://${this.user.apiLocation}/v1/project/public/${this.project_id}/index/projection/${this.id}/quadtree`;
   }
 
   async info() {

--- a/tests/arrow.test.js
+++ b/tests/arrow.test.js
@@ -1,29 +1,31 @@
-import { test } from "uvu";
-import * as arrow from "apache-arrow";
+import { test } from 'uvu';
+import * as arrow from 'apache-arrow';
 
+/**
 type TestTableOptions = {
   length: number;
   modality: "text" | "embedding";
 };
+ */
 
 export function make_test_table({
   length = 32,
-  modality = "text",
-}: Partial<TestTableOptions> = {}) {
-  type columns = {
+  modality = 'text',
+} /*: Partial<TestTableOptions>*/ = {}) {
+  /*  type columns = {
     id: arrow.Data;
     text: arrow.Data;
     embedding?: arrow.Data;
     date: arrow.Data;
-  };
-  const cols: columns = {
+  }; */
+  const cols /*: columns*/ = {
     id: create_id_column(length),
     text: create_text_column(length),
     embedding: create_embedding_column(length),
     date: create_date_column(length),
   };
-  if (modality === "text") {
-    delete cols["embedding"];
+  if (modality === 'text') {
+    delete cols['embedding'];
   }
   const tb = new arrow.RecordBatch(cols);
   return new arrow.Table(tb);
@@ -31,7 +33,7 @@ export function make_test_table({
 
 function create_date_column(length = 32) {
   const f = new arrow.TimestampNanosecond();
-  const dates: Date[] = [];
+  const dates = [];
   for (let i = 0; i < length; i++) {
     const datum = new Date(2002, 2, i, 2, 2, 2, 2);
     dates.push(datum);
@@ -61,7 +63,7 @@ function create_id_column(length = 32) {
 function create_embedding_column(length = 32, dims = 16) {
   const f = new arrow.FixedSizeList(
     dims,
-    new arrow.Field("inner", new arrow.Float16())
+    new arrow.Field('inner', new arrow.Float16())
   );
 
   let builder = arrow.makeBuilder({
@@ -86,17 +88,17 @@ function create_embedding_column(length = 32, dims = 16) {
  */
 function create_sample_wordlist(length) {
   const sample_words = [
-    "lorem",
-    "ipsum",
-    "dolor",
-    "sit",
-    "amet",
-    "consectetur",
-    "adipiscing",
-    "elit",
-    "sed",
+    'lorem',
+    'ipsum',
+    'dolor',
+    'sit',
+    'amet',
+    'consectetur',
+    'adipiscing',
+    'elit',
+    'sed',
   ];
-  const words: string[] = [];
+  const words = [];
   for (let i = 0; i < length; i++) {
     words.push(sample_words[Math.floor(Math.random() * sample_words.length)]);
   }

--- a/tests/project.test.js
+++ b/tests/project.test.js
@@ -1,59 +1,59 @@
 import { test } from 'uvu';
 import * as arrow from 'apache-arrow';
 import * as assert from 'uvu/assert';
-import { AtlasProject } from '../src/project';
-import { make_test_table } from './arrow.test';
-import { AtlasProjection } from '../src/projection';
-import { AtlasUser } from '../src/user';
-import { AtlasOrganization } from '../src/organization';
+import { AtlasProject } from '../dist/project.js';
+import { make_test_table } from './arrow.test.js';
+import { AtlasProjection } from '../dist/projection.js';
+import { AtlasUser } from '../dist/user.js';
+import { AtlasOrganization } from '../dist/organization.js';
 
 test('Full project flow', async () => {
   // get user
-  console.log('getting user')
+  console.log('getting user');
   const user = new AtlasUser({ useEnvToken: true });
   // get organization for user
-  console.log('getting organization')
+  console.log('getting organization');
   const organization = new AtlasOrganization(
     (await user.info()).organizations[0].organization_id,
     user
   );
   // create project in organization
-  console.log('creating project')
+  console.log('creating project');
   const project = await organization.create_project({
     project_name: 'a typescript test text project',
     unique_id_field: 'id',
     modality: 'text',
   });
   // fetch project from user and project id
-  console.log('fetching project')
+  console.log('fetching project');
   const project2 = new AtlasProject(project.id, user);
   assert.is(project2.id, project.id);
   // upload arrow table to project
-  console.log('uploading arrow')
+  console.log('uploading arrow');
   const tb = make_test_table({ length: 32, modality: 'text' });
   await project.uploadArrow(tb);
   // create index on project
-  console.log('creating index')
+  console.log('creating index');
   await project.createIndex({
     index_name: 'test index',
     indexed_field: 'text',
     colorable_fields: [],
   });
   // wait for index to be ready
-  console.log('waiting for index')
+  console.log('waiting for index');
   await project.wait_for_lock();
   // fetch index from project and index id
-  console.log('fetching index')
+  console.log('fetching index');
   const index = (await project.indices())[0];
-  console.log('fetching projection')
+  console.log('fetching projection');
   const orig_projection = (await index.projections())[0];
   // Re-instantiate with just the project; test if we properly infer the index.
-  console.log('re-instantiating projection')
+  console.log('re-instantiating projection');
   const projection = new AtlasProjection(orig_projection.id, { project });
   const inferred_index = await projection.index();
   assert.is(inferred_index.id, index.id);
   // delete project
-  console.log('deleting project')
+  console.log('deleting project');
   await project.delete();
 });
 

--- a/tests/user.test.js
+++ b/tests/user.test.js
@@ -1,12 +1,12 @@
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
-import { AtlasUser } from '../src/user';
-import { AtlasOrganization } from '../src/organization';
+import { AtlasUser } from '../dist/user.js';
+import { AtlasOrganization } from '../dist/organization.js';
 
 // TODO - should have a dedicated test account here
 
 test('AtlasOrganization test', async () => {
-  const user = new AtlasUser({  useEnvToken: true });
+  const user = new AtlasUser({ useEnvToken: true });
   const info = await user.info();
   const organization = new AtlasOrganization(
     info.organizations[0].organization_id,


### PR DESCRIPTION
We can lose the `Tenant` structures by just using `apiLocation`. I think eventually we'll determine we need this to be a URL, not a domain, so that we can access localhost, but I'll punt on that.

This PR also rewrites the test as a javascript, not typescript, which simplifies the testing process a bit.