### PR TITLE
refactor: rename project to dataset with back-compatible alias

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+# 0.9.6
+
+- Rename "AtlasProject" to "AtlasDataset" with backwards compatible alias.
+
 # 0.9.5
 
 - Fixed issue with duplicate detection parameters

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,18 @@
 import { BaseAtlasClass } from './user.js';
 import type { AtlasUser } from './user.js';
 import { AtlasProjection } from './projection.js';
-import { AtlasProject } from './project.js';
+import { AtlasDataset as AtlasDataset } from './project.js';
 import type { Table } from 'apache-arrow';
 
 type IndexInitializationOptions = {
   project_id?: Atlas.UUID;
-  project?: AtlasProject;
+  project?: AtlasDataset;
 };
 
 export class AtlasIndex extends BaseAtlasClass {
   id: Atlas.UUID;
   _projections?: AtlasProjection[] = undefined;
-  project: AtlasProject;
+  project: AtlasDataset;
 
   constructor(
     id: Atlas.UUID,
@@ -27,7 +27,7 @@ export class AtlasIndex extends BaseAtlasClass {
       throw new Error('project_id or project is required');
     }
     this.project =
-      options.project || new AtlasProject(options.project_id as string, user);
+      options.project || new AtlasDataset(options.project_id as string, user);
     this.id = id;
   }
   /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
-export { AtlasProject } from './project.js';
+export { AtlasDataset as AtlasProject } from './project.js';
+export { AtlasDataset } from './project.js';
 export { AtlasUser, APIError } from './user.js';
 export { AtlasOrganization } from './organization.js';
 export { AtlasProjection } from './projection.js';

--- a/src/organization.ts
+++ b/src/organization.ts
@@ -1,5 +1,5 @@
 import { AtlasUser, get_env_user } from './user.js';
-import { AtlasProject } from './project.js';
+import { AtlasDataset } from './project.js';
 
 type UUID = string;
 
@@ -44,7 +44,7 @@ export class AtlasOrganization {
     return info.projects;
   }
 
-  async create_project(options: ProjectInitOptions): Promise<AtlasProject> {
+  async create_project(options: ProjectInitOptions): Promise<AtlasDataset> {
     const info = (await this.info()) as OrganizationInfo;
     const user = this.user;
     if (options.unique_id_field === undefined) {
@@ -61,6 +61,6 @@ export class AtlasOrganization {
       ...options,
       organization_id: this.id,
     })) as CreateResponse;
-    return new AtlasProject(data['project_id'], user);
+    return new AtlasDataset(data['project_id'], user);
   }
 }

--- a/src/project.ts
+++ b/src/project.ts
@@ -7,7 +7,7 @@ import { AtlasIndex } from './index.js';
 import { OrganizationProjectInfo } from 'organization.js';
 type UUID = string;
 
-export function load_project(options: Atlas.LoadProjectOptions): AtlasProject {
+export function load_project(options: Atlas.LoadProjectOptions): AtlasDataset {
   throw new Error('Not implemented');
 }
 
@@ -57,11 +57,11 @@ type CreateAtlasIndexRequest = {
 };
 
 /**
- * An AtlasProject represents a single mutable dataset in Atlas. It provides an
+ * An AtlasDataset represents a single mutable dataset in Atlas. It provides an
  * interfaces to upload, update, and delete data, as well as create and delete
  * indices which handle specific views.
  */
-export class AtlasProject extends BaseAtlasClass {
+export class AtlasDataset extends BaseAtlasClass {
   _indices: AtlasIndex[] = [];
   _schema?: Schema | null;
   private _info?: Promise<Atlas.ProjectInfo>;
@@ -73,7 +73,7 @@ export class AtlasProject extends BaseAtlasClass {
    * an existing project, use the create_project or load_project functions.
    * @param user An existing AtlasUser object. If not provided, a new one will be created.
    *
-   * @returns An AtlasProject object.
+   * @returns An AtlasDataset object.
    */
   constructor(id: UUID | string, user?: AtlasUser) {
     super(user);
@@ -140,7 +140,7 @@ export class AtlasProject extends BaseAtlasClass {
     return new Promise((resolve, reject) => {
       const interval = setInterval(async () => {
         // Create a new project to clear the cache.
-        const renewed = new AtlasProject(this.id, this.user);
+        const renewed = new AtlasDataset(this.id, this.user);
         const info = (await renewed.info()) as Atlas.ProjectInfo;
         if (info.insert_update_delete_lock === false) {
           clearInterval(interval);

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -1,7 +1,7 @@
 import { Schema, Type, tableFromIPC, tableToIPC } from 'apache-arrow';
 import { BaseAtlasClass } from './user.js';
 import type { AtlasUser } from './user.js';
-import { AtlasProject } from './project.js';
+import { AtlasDataset } from './project.js';
 import type { AtlasIndex } from './index.js';
 
 type UUID = string;
@@ -10,7 +10,7 @@ export type DeleteTagRequest = {
   tag_id: UUID;
 };
 type ProjectionInitializationOptions = {
-  project?: AtlasProject;
+  project?: AtlasDataset;
   index?: AtlasIndex;
   project_id?: UUID;
   user?: AtlasUser;
@@ -82,7 +82,7 @@ type TagStatus = {
 };
 
 export class AtlasProjection extends BaseAtlasClass {
-  _project?: AtlasProject;
+  _project?: AtlasDataset;
   project_id: UUID;
   _index?: AtlasIndex;
   private _info?: Promise<Record<string, any>>;
@@ -261,9 +261,9 @@ export class AtlasProjection extends BaseAtlasClass {
     return this._schema;
   }
 
-  async project(): Promise<AtlasProject> {
+  async project(): Promise<AtlasDataset> {
     if (this._project === undefined) {
-      this._project = new AtlasProject(this.project_id, this.user);
+      this._project = new AtlasDataset(this.project_id, this.user);
     }
     return this._project;
   }

--- a/tests/project.test.js
+++ b/tests/project.test.js
@@ -1,7 +1,7 @@
 import { test } from 'uvu';
 import * as arrow from 'apache-arrow';
 import * as assert from 'uvu/assert';
-import { AtlasProject } from '../dist/project.js';
+import { AtlasDataset } from '../dist/project.js';
 import { make_test_table } from './arrow.test.js';
 import { AtlasProjection } from '../dist/projection.js';
 import { AtlasUser } from '../dist/user.js';
@@ -32,7 +32,7 @@ test('Full project flow', async () => {
   });
   // fetch project from user and project id
   console.log('fetching project');
-  const project2 = new AtlasProject(project.id, user);
+  const project2 = new AtlasDataset(project.id, user);
   assert.is(project2.id, project.id);
   // upload arrow table to project
   console.log('uploading arrow');


### PR DESCRIPTION
Renames "Project" to "Dataset" in code and docs, but continues to export an alias of AtlasDataset as AtlasProject for back-compatibility.