### PR TITLE
Viewer-refactor

### DIFF
--- a/src/embedding.ts
+++ b/src/embedding.ts
@@ -1,3 +1,4 @@
+import { AtlasViewer } from 'viewer.js';
 import { BaseAtlasClass, AtlasUser } from './user.js';
 
 type TaskType =
@@ -49,7 +50,7 @@ const BATCH_SIZE = 32;
  * const embeddings = await embedder.embed(documents)
  * ```
  *
- * GOOD -- Nomic will combine your small requests into several medium-size
+ * GOOD -- Nomic will combine your small requests into several medium-size ones.
  * ```js
  * const documents = ["Once upon a time", "there was a girl named Goldilocks", …, "and they all lived happily ever after"]
  * const embedder = new Embedder(myApiKey)
@@ -60,7 +61,7 @@ const BATCH_SIZE = 32;
  * const embeddings = await Promise.all(promises)
  * ```
  *
- * BAD -- You will generate many small, inefficient requests
+ * BAD -- You will generate many small, inefficient requests.
  * ```js
  *  * const documents = ["Once upon a time", "there was a girl named Goldilocks", …, "and they all lived happily ever after"]
  * const embedder = new Embedder(myApiKey)
@@ -98,28 +99,32 @@ export class Embedder extends BaseAtlasClass<{}> {
    */
   constructor(apiKey: string, options: EmbedderOptions);
   constructor(user: AtlasUser, options: EmbedderOptions);
-  constructor(input: string | AtlasUser, options: EmbedderOptions = {}) {
+  constructor(viewer: AtlasViewer, options: EmbedderOptions);
+  constructor(
+    input: string | AtlasUser | AtlasViewer,
+    options: EmbedderOptions = {}
+  ) {
     const { model, taskType } = {
       // Defaults
       model: 'nomic-embed-text-v1.5' as EmbeddingModel,
       taskType: 'search_document' as TaskType,
       ...options,
     };
-    let user: AtlasUser;
+    let viewer: AtlasViewer | AtlasUser;
     if (typeof input === 'string') {
-      user = new AtlasUser({
+      viewer = new AtlasViewer({
         apiKey: input,
       });
     } else {
-      user = input;
+      viewer = input;
     }
     // Handle authentication the normal way.
-    super(user);
+    super(viewer);
     this.model = model;
     this.taskType = taskType;
   }
 
-  endpoint(): string {
+  protected endpoint(): string {
     throw new Error('Embedders do not have info() property.');
   }
 
@@ -254,7 +259,7 @@ export async function embed(
 ): Promise<Embedding | Embedding[]> {
   const machine =
     apiKey === undefined
-      ? new Embedder(new AtlasUser({ useEnvToken: true }), options)
+      ? new Embedder(new AtlasViewer({ useEnvToken: true } as const), options)
       : new Embedder(apiKey, options);
 
   if (typeof value === 'string') {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -39,4 +39,45 @@ declare namespace Atlas {
   };
   type Payload = Record<string, any> | Uint8Array | null;
   type AtlasUser = {};
+
+  type Envlogin = {
+    useEnvToken: true;
+    apiLocation?: never;
+    apiKey?: never;
+    bearerToken?: never;
+  };
+  type ApiKeyLogin = {
+    useEnvToken?: never;
+    apiLocation?: string;
+    apiKey: string;
+    bearerToken?: never;
+  };
+  type BearerTokenLogin = {
+    useEnvToken?: never;
+    bearerToken: string;
+    apiLocation?: string;
+    apiKey?: never;
+  };
+  type AnonViewerLogin = {
+    useEnvToken?: never;
+    bearerToken?: never;
+    apiLocation?: string;
+    apiKey?: never;
+  };
+  type LoginParams =
+    | Envlogin
+    | ApiKeyLogin
+    | BearerTokenLogin
+    | AnonViewerLogin;
+
+  type ApiCallOptions = {
+    octetStreamAsUint8?: boolean;
+  };
+
+  type TokenRefreshResponse = any;
+  interface Credentials {
+    refresh_token: string | null;
+    token: string;
+    expires: number;
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import type { AtlasUser } from './user.js';
 import { AtlasProjection } from './projection.js';
 import { AtlasDataset as AtlasDataset } from './project.js';
 import type { Table } from 'apache-arrow';
+import { AtlasViewer } from 'viewer.js';
 
 type IndexInitializationOptions = {
   project_id?: Atlas.UUID;
@@ -16,7 +17,7 @@ export class AtlasIndex extends BaseAtlasClass<{}> {
 
   constructor(
     id: Atlas.UUID,
-    user?: AtlasUser,
+    user?: AtlasUser | AtlasViewer,
     options: IndexInitializationOptions = {}
   ) {
     super(user);
@@ -31,7 +32,7 @@ export class AtlasIndex extends BaseAtlasClass<{}> {
     this.id = id;
   }
 
-  endpoint(): string {
+  protected endpoint(): string {
     throw new Error('There is no info property on Atlas Indexes');
   }
 
@@ -78,7 +79,7 @@ export class AtlasIndex extends BaseAtlasClass<{}> {
           ?.projections || [];
       this._projections = projections.map(
         (d) =>
-          new AtlasProjection(d.id as string, this.user, {
+          new AtlasProjection(d.id as string, this.viewer, {
             index: this,
             project: this.project,
           })

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 export { AtlasDataset as AtlasProject } from './project.js';
 export { AtlasDataset } from './project.js';
-export { AtlasUser, APIError } from './user.js';
+export { AtlasUser } from './user.js';
+export { APIError, AtlasViewer } from './viewer.js';
 export { AtlasOrganization } from './organization.js';
 export { AtlasProjection } from './projection.js';
 export { AtlasIndex } from './index.js';

--- a/src/organization.ts
+++ b/src/organization.ts
@@ -1,4 +1,4 @@
-import { AtlasUser, BaseAtlasClass, get_env_user } from './user.js';
+import { AtlasUser, BaseAtlasClass, getEnvViewer } from './user.js';
 import { AtlasDataset } from './project.js';
 
 type UUID = string;
@@ -26,7 +26,7 @@ export class AtlasOrganization extends BaseAtlasClass<OrganizationInfo> {
     this.id = id;
   }
 
-  endpoint() {
+  protected endpoint() {
     return `/v1/organization/${this.id}`;
   }
 
@@ -36,7 +36,6 @@ export class AtlasOrganization extends BaseAtlasClass<OrganizationInfo> {
   }
 
   async create_project(options: ProjectInitOptions): Promise<AtlasDataset> {
-    const user = this.user;
     if (options.unique_id_field === undefined) {
       throw new Error('unique_id_field is required');
     }
@@ -47,10 +46,10 @@ export class AtlasOrganization extends BaseAtlasClass<OrganizationInfo> {
     type CreateResponse = {
       project_id: UUID;
     };
-    const data = (await user.apiCall(`/v1/project/create`, 'POST', {
+    const data = (await this.apiCall(`/v1/project/create`, 'POST', {
       ...options,
       organization_id: this.id,
     })) as CreateResponse;
-    return new AtlasDataset(data['project_id'], user);
+    return new AtlasDataset(data['project_id'], this.viewer);
   }
 }

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,10 +1,9 @@
 import type { Schema, Table } from 'apache-arrow';
-import type { ApiCallOptions } from './user.js';
 import { tableToIPC, tableFromJSON, tableFromIPC } from 'apache-arrow';
-import { AtlasUser, get_env_user, BaseAtlasClass } from './user.js';
+import { AtlasUser, BaseAtlasClass } from './user.js';
 import { AtlasIndex } from './index.js';
+import { AtlasViewer } from 'viewer.js';
 // get the API key from the node environment
-import { OrganizationProjectInfo } from 'organization.js';
 type UUID = string;
 
 export function load_project(options: Atlas.LoadProjectOptions): AtlasDataset {
@@ -74,7 +73,7 @@ export class AtlasDataset extends BaseAtlasClass<Atlas.ProjectInfo> {
    *
    * @returns An AtlasDataset object.
    */
-  constructor(id: UUID | string, user?: AtlasUser) {
+  constructor(id: UUID | string, user?: AtlasUser | AtlasViewer) {
     super(user);
     // check if id is a valid UUID
 
@@ -116,10 +115,16 @@ export class AtlasDataset extends BaseAtlasClass<Atlas.ProjectInfo> {
     method: 'GET' | 'POST',
     payload: Atlas.Payload = null,
     headers: null | Record<string, string> = null,
-    options: ApiCallOptions = {}
+    options: Atlas.ApiCallOptions = {}
   ) {
     const fixedEndpoint = this._fixEndpointURL(endpoint);
-    return this.user.apiCall(fixedEndpoint, method, payload, headers, options);
+    return this.viewer.apiCall(
+      fixedEndpoint,
+      method,
+      payload,
+      headers,
+      options
+    );
   }
 
   async delete() {
@@ -139,7 +144,7 @@ export class AtlasDataset extends BaseAtlasClass<Atlas.ProjectInfo> {
     return new Promise((resolve, reject) => {
       const interval = setInterval(async () => {
         // Create a new project to clear the cache.
-        const renewed = new AtlasDataset(this.id, this.user);
+        const renewed = new AtlasDataset(this.id, this.viewer);
         const info = (await renewed.info()) as Atlas.ProjectInfo;
         if (info.insert_update_delete_lock === false) {
           clearInterval(interval);
@@ -151,7 +156,7 @@ export class AtlasDataset extends BaseAtlasClass<Atlas.ProjectInfo> {
     });
   }
 
-  endpoint() {
+  protected endpoint() {
     return `/v1/project/${this.id}`;
   }
 
@@ -176,7 +181,7 @@ export class AtlasDataset extends BaseAtlasClass<Atlas.ProjectInfo> {
     }
     const options = { project: this };
     this._indices = atlas_indices.map(
-      (d) => new AtlasIndex(d['id'], this.user, options)
+      (d) => new AtlasIndex(d['id'], this.viewer, options)
     );
     return this._indices;
   }
@@ -268,13 +273,13 @@ export class AtlasDataset extends BaseAtlasClass<Atlas.ProjectInfo> {
       fields
     );
     const id = response as string;
-    return new AtlasIndex(id, this.user, { project: this });
+    return new AtlasIndex(id, this.viewer, { project: this });
   }
 
   async delete_data(ids: string[]): Promise<void> {
     // TODO: untested
     // const info = await this.info
-    await this.user.apiCall('/v1/project/data/delete', 'POST', {
+    await this.viewer.apiCall('/v1/project/data/delete', 'POST', {
       project_id: this.id,
       datum_ids: ids,
     });

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -3,6 +3,7 @@ import { BaseAtlasClass } from './user.js';
 import type { AtlasUser } from './user.js';
 import { AtlasDataset } from './project.js';
 import type { AtlasIndex } from './index.js';
+import { AtlasViewer } from 'viewer.js';
 
 export type ProjectGetInfo = Record<string, any>;
 
@@ -92,11 +93,11 @@ export class AtlasProjection extends BaseAtlasClass<ProjectGetInfo> {
 
   constructor(
     public id: UUID,
-    user?: AtlasUser,
+    user?: AtlasUser | AtlasViewer,
     options: ProjectionInitializationOptions = {}
   ) {
     const { project, project_id } = options;
-    super(user || project?.user);
+    super(user || project?.viewer);
 
     if (project_id === undefined && project === undefined) {
       throw new Error('project_id or project is required');
@@ -266,7 +267,7 @@ export class AtlasProjection extends BaseAtlasClass<ProjectGetInfo> {
 
   async project(): Promise<AtlasDataset> {
     if (this._project === undefined) {
-      this._project = new AtlasDataset(this.project_id, this.user);
+      this._project = new AtlasDataset(this.project_id, this.viewer);
     }
     return this._project;
   }
@@ -297,13 +298,13 @@ export class AtlasProjection extends BaseAtlasClass<ProjectGetInfo> {
    * 'public' may be be added in fetching.
    */
   get quadtree_root(): string {
-    const protocol = this.user.apiLocation.startsWith('localhost')
+    const protocol = this.viewer.apiLocation.startsWith('localhost')
       ? 'http'
       : 'https';
-    return `${protocol}://${this.user.apiLocation}/v1/project/${this.project_id}/index/projection/${this.id}/quadtree`;
+    return `${protocol}://${this.viewer.apiLocation}/v1/project/${this.project_id}/index/projection/${this.id}/quadtree`;
   }
 
-  endpoint() {
+  protected endpoint() {
     return `/v1/project/${this.project_id}/index/projection/${this.id}`;
   }
 }

--- a/src/user.ts
+++ b/src/user.ts
@@ -1,5 +1,5 @@
+import { AtlasViewer } from 'viewer.js';
 import type { OrganizationProjectInfo } from './organization.js';
-import { Table, tableFromIPC } from 'apache-arrow';
 
 export const isNode =
   typeof process !== 'undefined' && process.versions && process.versions.node;
@@ -10,22 +10,27 @@ export type LoadedObject<
 > = T & { i: U };
 
 export abstract class BaseAtlasClass<InfoType extends Record<string, any>> {
-  user: AtlasUser;
+  viewer: AtlasViewer;
   // To avoid multiple calls, the first request sets the _info property.
   protected _info: Promise<InfoType> | undefined;
   // Once info resolves, it populates here.
   protected _i: InfoType | undefined;
 
-  constructor(user?: AtlasUser) {
-    if (user === undefined) {
-      this.user = get_env_user();
+  constructor(viewer?: AtlasUser | AtlasViewer) {
+    if (viewer === undefined) {
+      this.viewer = getEnvViewer();
     } else {
-      this.user = user;
+      // Back-compatibility. Remove in 1.0.
+      if ((viewer as AtlasUser).projects !== undefined) {
+        this.viewer = (viewer as AtlasUser).viewer;
+      } else {
+        this.viewer = viewer as AtlasViewer;
+      }
     }
   }
 
   // Defines which endpoint returns the info object.
-  abstract endpoint(): string;
+  protected abstract endpoint(): string;
 
   /**
    * returns the object's information; this may be undefined
@@ -46,7 +51,7 @@ export abstract class BaseAtlasClass<InfoType extends Record<string, any>> {
     if (!bustCache && this._info !== undefined) {
       return this._info;
     }
-    this._info = this.user.apiCall(this.endpoint(), 'GET').then((info) => {
+    this._info = this.viewer.apiCall(this.endpoint(), 'GET').then((info) => {
       this._i = info as InfoType;
       return info;
     }) as Promise<InfoType>;
@@ -72,114 +77,18 @@ export abstract class BaseAtlasClass<InfoType extends Record<string, any>> {
     headers: null | Record<string, string> = null
   ) {
     // make an API call
-    return this.user.apiCall(endpoint, method, payload, headers);
+    return this.viewer.apiCall(endpoint, method, payload, headers);
   }
 }
 
-export class APIError extends Error {
-  status: number;
-  statusText: string;
-  headers: any;
-  responseBody: string | null;
+let viewer: AtlasViewer | undefined = undefined;
 
-  constructor(
-    status: number,
-    statusText: string,
-    headers: any,
-    responseBody?: string
-  ) {
-    super(`Error ${status}: ${statusText}`);
-    this.status = status;
-    this.statusText = statusText;
-    this.headers = headers;
-    this.responseBody = responseBody || null;
-    Object.setPrototypeOf(this, APIError.prototype);
-  }
-}
-
-export type ApiCallOptions = {
-  octetStreamAsUint8?: boolean;
-};
-
-type TokenRefreshResponse = any;
-interface Credentials {
-  refresh_token: string | null;
-  token: string;
-  expires: number;
-}
-
-function validateApiHttpResponse(response: Response): Response {
-  if (response.status >= 500 && response.status < 600) {
-    throw new Error(
-      'Cannot contact establish a connection with Nomic services.'
-    );
-  }
-  return response;
-}
-
-/**
- *
- * @param apiKey The Atlas user API key to use.
- * @param apiLocation The URL of the API to query.
- * @returns
- */
-async function get_access_token(
-  apiKey: string | undefined,
-  apiLocation: string = 'api-atlas.nomic.ai'
-): Promise<Credentials> {
-  if (apiKey === undefined) {
-    throw new Error(
-      'Could not authorize you with Nomic. Please see the readme for instructions on setting ATLAS_API_KEY in your path.'
-    );
-  }
-
-  if (apiKey.startsWith('nk-')) {
-    const tokenInfo: Credentials = {
-      token: apiKey,
-      refresh_token: null,
-      expires: Date.now() + 80000,
-    };
-    return tokenInfo;
-  }
-  const protocol = apiLocation.startsWith('localhost') ? 'http' : 'https';
-
-  const response = await fetch(
-    `${protocol}://${apiLocation}/v1/user/token/refresh/${apiKey}`
-  );
-  const validatedResponse = validateApiHttpResponse(response);
-
-  if (validatedResponse.status !== 200) {
-    throw new Error(
-      'Could not authorize you with Nomic. Run `nomic login` to re-authenticate.'
-    );
-  }
-
-  const access_token = (
-    (await validatedResponse.json()) as TokenRefreshResponse
-  ).access_token as string;
-
-  if (access_token === undefined) {
-    throw new Error(
-      'Could not authorize you with Nomic. Please see the readme for instructions on setting ATLAS_API_KEY in your path.'
-    );
-  }
-
-  const tokenInfo: Credentials = {
-    refresh_token: apiKey,
-    token: access_token,
-    expires: Date.now() + 80000,
-  };
-
-  return tokenInfo;
-}
-
-let user: AtlasUser | undefined = undefined;
-export function get_env_user(): AtlasUser {
-  if (user === undefined) {
+export function getEnvViewer(): AtlasViewer {
+  if (viewer === undefined) {
     console.warn('CREATING USER FROM ENV');
-    user = new AtlasUser({ useEnvToken: true });
+    viewer = new AtlasViewer({ useEnvToken: true });
   }
-  return user;
+  return viewer;
 }
 
 type UUID = string;
@@ -201,97 +110,33 @@ export type UserInfo = {
   organizations: OrganizationUserInfo[];
 };
 
-type Envlogin = {
-  useEnvToken: true;
-  apiLocation?: never;
-  apiKey?: never;
-  bearerToken?: never;
-};
+type ViewMakerArgs = ConstructorParameters<typeof AtlasViewer>;
 
-type ApiKeyLogin = {
-  useEnvToken?: never;
-  apiLocation?: string;
-  apiKey: string;
-  bearerToken?: never;
-};
-
-type BearerTokenLogin = {
-  useEnvToken?: never;
-  bearerToken: string;
-  apiLocation?: string;
-  apiKey?: never;
-};
-
-type AnonUser = {
-  useEnvToken?: never;
-  bearerToken?: never;
-  apiLocation?: string;
-  apiKey?: never;
-};
-
-type LoginParams = Envlogin | ApiKeyLogin | BearerTokenLogin | AnonUser;
-
-export class AtlasUser {
+export class AtlasUser extends BaseAtlasClass<UserInfo> {
   /* 
   An AtlasUser is a registered user. The class contains 
   both information about the user and the credentials
   needed to make API calls.
   */
-  private credentials: Promise<Credentials | null>;
-  public anonymous: boolean = false;
-  apiLocation: string;
-  _info: Promise<UserInfo> | undefined = undefined;
 
-  /**`
-   *
-   * @param params
-   *  An object that corresponds to one of the accepted login methods
-   *    Envlogin: Uses the environment variable
-   *      must have `useEnvToken: true`
-   *    ApiKeyLogin: Uses an api key
-   *      must have `apiKey: string`
-   *    BearerTokenLogin: Uses a bearer token
-   *      must have `bearerToken: string`
-   *    AnonUser: No credentials, used for anonymous users
-   *
-   */
+  // @deprecated
+  constructor(...args: ViewMakerArgs) {
+    // For the time being, the AtlasUser can be constructed to created a viewer inside of it.
+    // As time goes on, this will be deprecated.
+    const viewer = new AtlasViewer(...args);
+    super(viewer);
+  }
 
-  constructor(params: Envlogin);
-  constructor(params: ApiKeyLogin);
-  constructor(params: BearerTokenLogin);
-  constructor(params: AnonUser);
-  constructor(params: LoginParams) {
-    const { useEnvToken, apiKey, bearerToken, apiLocation } = params;
+  protected endpoint() {
+    return '/v1/user/';
+  }
 
-    // If apiLocation is not specified, use the environment variable
-    // If the environment variable is not set, use the default
-    if (apiLocation) {
-      this.apiLocation = apiLocation;
-    } else if (process.env.ATLAS_API_DOMAIN) {
-      this.apiLocation = process.env.ATLAS_API_DOMAIN;
-    } else {
-      this.apiLocation = 'api-atlas.nomic.ai';
-    }
+  get anonymous() {
+    return this.viewer.anonymous;
+  }
 
-    if (useEnvToken) {
-      // using the token in the environment
-      const apiKey = process.env.ATLAS_API_KEY;
-      this.credentials = get_access_token(apiKey, this.apiLocation);
-    } else if (apiKey) {
-      // using an api key
-      this.credentials = get_access_token(apiKey, this.apiLocation);
-    } else if (bearerToken) {
-      // using a bearer token
-      this.credentials = Promise.resolve({
-        refresh_token: null,
-        token: bearerToken,
-        expires: Date.now() + 80000,
-      });
-    } else {
-      // no credentials
-      this.anonymous = true;
-      this.credentials = Promise.resolve(null);
-    }
+  get apiLocation() {
+    return this.viewer.apiLocation;
   }
   /**
    *
@@ -321,117 +166,5 @@ export class AtlasUser {
     return organizations.map(
       (org) => new AtlasOrganization(org.organization_id, this)
     );
-  }
-
-  async info() {
-    if (this._info !== undefined) {
-      return this._info;
-    }
-    this._info = (await this.apiCall('/v1/user/', 'GET')) as Promise<UserInfo>;
-    return this._info;
-  }
-
-  /**
-   * Call the API and return the results as deserialized JSON
-   * or Arrow.
-   *
-   * @param endpoint The nomic API endpoint to call. If it doesn't begin with a slash, it will be added.
-   * @param method POST or GET
-   * @param payload The binary or JSON payload sent with the request.
-   * @param headers Additional headers to send with the request
-   * @returns
-   */
-
-  async apiCall(
-    endpoint: string,
-    method: 'GET' | 'POST' = 'GET',
-    payload: Atlas.Payload = null,
-    headers: null | Record<string, string> = null,
-    options: ApiCallOptions = { octetStreamAsUint8: false }
-  ): Promise<
-    Record<string, any> | string | Array<any> | Table | Uint8Array | null
-  > {
-    // make an API call
-
-    if (headers === null) {
-      const credentials = await this.credentials;
-      if (credentials === null) {
-        headers = {};
-      } else {
-        headers = { Authorization: `Bearer ${credentials.token}` };
-      }
-    }
-
-    // Bigints are passed to the API
-    // which would break JSON.stringify.
-    const replacer = (key: any, value: any) =>
-      typeof value === 'bigint' ? value.toString() : value;
-
-    let body: RequestInit['body'] = null;
-    if (payload instanceof Uint8Array) {
-      headers['Content-Type'] = 'application/octet-stream';
-      body = payload;
-    } else if (payload !== null) {
-      headers['Content-Type'] = 'application/json';
-      body = JSON.stringify(payload, replacer);
-    } else {
-      headers['Content-Type'] = 'application/json';
-      body = null;
-    }
-    const protocol = this.apiLocation.startsWith('localhost')
-      ? 'http'
-      : 'https';
-
-    const url = `${protocol}://${this.apiLocation}${endpoint}`;
-    const params = {
-      method,
-      headers: {
-        ...headers,
-      },
-      body,
-    } as RequestInit;
-    const response = await fetch(url, params);
-
-    if (response.status < 200 || response.status > 299) {
-      const responseBody = await response.text();
-      throw new APIError(
-        response.status,
-        response.statusText,
-        response.headers,
-        responseBody
-      );
-    }
-
-    // Deserialize the response
-    let returnval;
-    if (response.headers.get('Content-Type') === 'application/json') {
-      const json = await response.json();
-      returnval = json;
-    } else if (
-      response.headers.get('Content-Type') === 'application/octet-stream'
-    ) {
-      const buffer = await response.arrayBuffer();
-      const view = new Uint8Array(buffer);
-      // Test that the first five bytes are the magic number 'ARROW'
-      if (view.slice(0, 5).toString() === '65,82,82,79,87') {
-        // It's Arrow.
-        if (options.octetStreamAsUint8) {
-          returnval = view;
-        } else {
-          returnval = tableFromIPC(view);
-        }
-      } else {
-        // It's not Arrow.
-        returnval = view;
-      }
-    } else if (response.headers.get('Content-Type') === null) {
-      // Successful deletion attempts return this.
-      return null;
-    } else {
-      throw new Error(
-        `Unknown unhandled type: ${response.headers.get('Content-Type')}`
-      );
-    }
-    return returnval;
   }
 }

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1,0 +1,261 @@
+import { Table, tableFromIPC } from 'apache-arrow';
+import { version } from '../package.json';
+
+export class AtlasViewer {
+  /* 
+  An AtlasViewer represents an agent in atlas system; it manages all credentials
+  needed to make API calls. All fetch requests to the Atlas API must be mediated through
+  this class.
+  */
+
+  // The credentials for the user.
+  private credentials: Promise<Atlas.Credentials | null>;
+  // Is this the anonymous viewer who has no special credentials with the API?
+  public anonymous: boolean = false;
+  // The location of the endpoint being called. Usually api-atlas.nomic.ai, but may
+  // differ in testing or enterprise deployments.
+  apiLocation: string;
+
+  /**`
+   *
+   * @param params
+   *  An object that corresponds to one of the accepted login methods
+   *    Envlogin: Uses the environment variable
+   *      must have `useEnvToken: true`
+   *    TokenLogin: Uses a bearer token or Nomic API key.
+   *      must have `token: string`
+   *    AnonUser: No credentials, used for anonymous Viewer
+   *
+   */
+
+  constructor(params: Atlas.Envlogin);
+  constructor(params: Atlas.ApiKeyLogin);
+  constructor(params: Atlas.BearerTokenLogin);
+  constructor(params: Atlas.AnonViewerLogin);
+  constructor(params: Atlas.LoginParams) {
+    const { useEnvToken, apiKey, bearerToken, apiLocation } = params;
+
+    // If apiLocation is not specified, use the environment variable
+    // If the environment variable is not set, use the default
+    if (apiLocation) {
+      this.apiLocation = apiLocation;
+    } else if (process.env.ATLAS_API_DOMAIN) {
+      this.apiLocation = process.env.ATLAS_API_DOMAIN;
+    } else {
+      this.apiLocation = 'api-atlas.nomic.ai';
+    }
+
+    if (useEnvToken) {
+      // using the token in the environment
+      const apiKey = process.env.ATLAS_API_KEY;
+      this.credentials = get_access_token(apiKey, this.apiLocation);
+    } else if (apiKey) {
+      // using an api key
+      this.credentials = get_access_token(apiKey, this.apiLocation);
+    } else if (bearerToken) {
+      // using a bearer token
+      this.credentials = Promise.resolve({
+        refresh_token: null,
+        token: bearerToken,
+        expires: Date.now() + 80000,
+      });
+    } else {
+      // no credentials
+      this.anonymous = true;
+      this.credentials = Promise.resolve(null);
+    }
+  }
+
+  /**
+   * Call the API and return the results as deserialized JSON
+   * or Arrow.
+   *
+   * @param endpoint The nomic API endpoint to call. If it doesn't begin with a slash, it will be added.
+   * @param method POST or GET
+   * @param payload The binary or JSON payload sent with the request.
+   * @param headers Additional headers to send with the request
+   * @returns
+   */
+
+  async apiCall(
+    endpoint: string,
+    method: 'GET' | 'POST' = 'GET',
+    payload: Atlas.Payload = null,
+    headers: null | Record<string, string> = null,
+    options: Atlas.ApiCallOptions = { octetStreamAsUint8: false }
+  ): Promise<
+    Record<string, any> | string | Array<any> | Table | Uint8Array | null
+  > {
+    // make an API call
+
+    if (headers === null) {
+      const credentials = await this.credentials;
+      if (credentials === null) {
+        headers = {};
+      } else {
+        headers = { Authorization: `Bearer ${credentials.token}` };
+      }
+    }
+
+    headers['User-Agent'] = `ts-nomic/${version}`;
+
+    // Bigints are passed to the API
+    // which would break JSON.stringify.
+    const replacer = (key: any, value: any) =>
+      typeof value === 'bigint' ? value.toString() : value;
+
+    let body: RequestInit['body'] = null;
+
+    if (payload instanceof Uint8Array) {
+      headers['Content-Type'] = 'application/octet-stream';
+      body = payload;
+    } else if (payload !== null) {
+      headers['Content-Type'] = 'application/json';
+      body = JSON.stringify(payload, replacer);
+    } else {
+      headers['Content-Type'] = 'application/json';
+      body = null;
+    }
+    const protocol = this.apiLocation.startsWith('localhost')
+      ? 'http'
+      : 'https';
+
+    const url = `${protocol}://${this.apiLocation}${endpoint}`;
+    const params = {
+      method,
+      headers: {
+        ...headers,
+      },
+      body,
+    } as RequestInit;
+    const response = await fetch(url, params);
+
+    if (response.status < 200 || response.status > 299) {
+      const responseBody = await response.text();
+      throw new APIError(
+        response.status,
+        response.statusText,
+        response.headers,
+        responseBody
+      );
+    }
+
+    // Deserialize the response
+    let returnval;
+    if (response.headers.get('Content-Type') === 'application/json') {
+      const json = await response.json();
+      returnval = json;
+    } else if (
+      response.headers.get('Content-Type') === 'application/octet-stream'
+    ) {
+      const buffer = await response.arrayBuffer();
+      const view = new Uint8Array(buffer);
+      // Test that the first five bytes are the magic number 'ARROW'
+      if (view.slice(0, 5).toString() === '65,82,82,79,87') {
+        // It's Arrow.
+        if (options.octetStreamAsUint8) {
+          returnval = view;
+        } else {
+          returnval = tableFromIPC(view);
+        }
+      } else {
+        // It's not Arrow.
+        returnval = view;
+      }
+    } else if (response.headers.get('Content-Type') === null) {
+      // Successful deletion attempts return this.
+      return null;
+    } else {
+      throw new Error(
+        `Unknown unhandled type: ${response.headers.get('Content-Type')}`
+      );
+    }
+    return returnval;
+  }
+}
+
+/**
+ *
+ * @param apiKey The Atlas user API key to use.
+ * @param apiLocation The URL of the API to query.
+ * @returns
+ */
+async function get_access_token(
+  apiKey: string | undefined,
+  apiLocation: string = 'api-atlas.nomic.ai'
+): Promise<Atlas.Credentials> {
+  if (apiKey === undefined) {
+    throw new Error(
+      'Could not authorize you with Nomic. Please see the readme for instructions on setting ATLAS_API_KEY in your path.'
+    );
+  }
+
+  if (apiKey.startsWith('nk-')) {
+    const tokenInfo: Atlas.Credentials = {
+      token: apiKey,
+      refresh_token: null,
+      expires: Date.now() + 80000,
+    };
+    return tokenInfo;
+  }
+  const protocol = apiLocation.startsWith('localhost') ? 'http' : 'https';
+
+  const response = await fetch(
+    `${protocol}://${apiLocation}/v1/user/token/refresh/${apiKey}`
+  );
+  const validatedResponse = validateApiHttpResponse(response);
+
+  if (validatedResponse.status !== 200) {
+    throw new Error(
+      'Could not authorize you with Nomic. Run `nomic login` to re-authenticate.'
+    );
+  }
+
+  const access_token = (
+    (await validatedResponse.json()) as Atlas.TokenRefreshResponse
+  ).access_token as string;
+
+  if (access_token === undefined) {
+    throw new Error(
+      'Could not authorize you with Nomic. Please see the readme for instructions on setting ATLAS_API_KEY in your path.'
+    );
+  }
+
+  const tokenInfo: Atlas.Credentials = {
+    refresh_token: apiKey,
+    token: access_token,
+    expires: Date.now() + 80000,
+  };
+
+  return tokenInfo;
+}
+
+function validateApiHttpResponse(response: Response): Response {
+  if (response.status >= 500 && response.status < 600) {
+    throw new Error(
+      'Cannot contact establish a connection with Nomic services.'
+    );
+  }
+  return response;
+}
+
+export class APIError extends Error {
+  status: number;
+  statusText: string;
+  headers: any;
+  responseBody: string | null;
+
+  constructor(
+    status: number,
+    statusText: string,
+    headers: any,
+    responseBody?: string
+  ) {
+    super(`Error ${status}: ${statusText}`);
+    this.status = status;
+    this.statusText = statusText;
+    this.headers = headers;
+    this.responseBody = responseBody || null;
+    Object.setPrototypeOf(this, APIError.prototype);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,18 +2,12 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "module": "es2020",
-    "lib": [
-      "es2020",
-      "DOM"
-    ],
+    "lib": ["es2020", "DOM"],
     "paths": {
-      "*": [
-        "src/*"
-      ],
-      "@types/*": [
-        "types/*"
-      ]
+      "*": ["src/*"],
+      "@types/*": ["types/*"]
     },
+    "resolveJsonModule": true,
     "target": "es2020",
     "sourceMap": false,
     "esModuleInterop": true,
@@ -26,9 +20,5 @@
     "strict": true,
     "declaration": true
   },
-  "include": [
-    "global.d.ts",
-    "src/global.d.ts",
-    "src/**/*.ts"
-  ]
+  "include": ["global.d.ts", "src/global.d.ts", "src/**/*.ts"]
 }


### PR DESCRIPTION
This PR disentangles two concepts in the module:

1. The AtlasUser in the system, which is a set of information like an e-mail, a name, a profile picture, etc. 
2. The basket of permissions that we hit the API endpoint with.

Fusing them together leads to a monstrous solipsism where the AtlasUser cannot imagine any user other than himself. He cannot collaborate with other AtlasUsers unless they give him full access to their APIKeys and authority to hit endpoints with them.

Following practice at Meta, we introduce a new fundamental class called the `AtlasViewer`, which is the agent making requests. `AtlasUser` is just the person in the system. For the time being `AtlasUser` still accepts keys in its constructor, but it passes them through to the underlying AtlasViewer: this behavior will probably be deprecated in version 1.0.