### PR TITLE
Nom 1729 next releases

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -40,13 +40,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
+      - name: Configure Git
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
       - run: npm ci
-      - name: Set version to release tag
-        run: npm version ${{ github.event.release.tag_name }} --no-git-tag-version
+      - name: Update version and commit
+        run: |
+          npm version ${{ github.event.release.tag_name }} --no-git-tag-version
+          git add package.json package-lock.json
+          git commit -m "Bump version to ${{ github.event.release.tag_name }}"
+          git push
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+      - name: Update release notes
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: context.payload.release.id,
+              body: context.payload.release.body + '\n\nThis release has been published to npm.'
+            })

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,8 +1,10 @@
-name: Publish @next release to npm
+name: Publish to npm
 on:
   push:
     branches:
       - main
+  release:
+    types: [published]
 
 permissions:
   contents: write
@@ -10,11 +12,12 @@ permissions:
   deployments: write
 
 jobs:
-  publish:
+  publish-next:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
@@ -23,13 +26,27 @@ jobs:
         run: |
           git config --global user.email "github-actions@github.com"
           git config --global user.name "GitHub Actions"
-      - run: npm version prerelease --preid=next
-      - name: Commit bumped version
+      - name: Get latest version and bump
         run: |
-          # git add package.json package-lock.json
-          # git commit -m "Bump version to $(node -p "require('./package.json').version")"
-          git push
-
+          LATEST_VERSION=$(npm view . version)
+          npm version $LATEST_VERSION --no-git-tag-version
+          npm version prerelease --preid=next
       - run: npm publish --tag next
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+
+  publish-release:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - name: Set version to release tag
+        run: npm version ${{ github.event.release.tag_name }} --no-git-tag-version
+      - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}


### PR DESCRIPTION
Automatically publish every merge to main with an @next tag, and automatically publish every tagged release rather than requiring publishing locally to npm. For tagged releases, also increment `package.json` to align to the version number.
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 16cf8a4a0bce151f4a1d54fe0af2b82bc3a25c38  | 
|--------|--------|

### Summary:
Automate npm publishing for pushes to `main` and published releases by modifying `.github/workflows/npm-publish.yml`.

**Key points**:
- Modify `.github/workflows/npm-publish.yml` to automate npm publishing.
- Add `publish-next` job to handle pushes to `main` branch.
- `publish-next` job bumps version with `next` preid and publishes with `next` tag.
- Add `publish-release` job to handle published releases.
- `publish-release` job updates version to match release tag, commits, and publishes to npm.
- Update GitHub Actions versions to `v3` for `checkout` and `setup-node`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->