### PR TITLE
ci: fix publish line

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -42,6 +42,6 @@ jobs:
 
           # Update package.json
           npm version $FINAL_VERSION --no-git-tag-version
-          npm publish --preid=next
+          npm publish --tag=next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Publish with --tag=next, not --preid=next
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 79eff0066cc52f026260ca080cf0251216073a54  | 
|--------|--------|

### Summary:
Change npm publish command to use `--tag=next` instead of `--preid=next` in `.github/workflows/npm-publish.yml`.

**Key points**:
- Update `.github/workflows/npm-publish.yml` to change the npm publish command.
- Replace `--preid=next` with `--tag=next` in the `npm publish` command.
- Ensures the package is published with the `next` tag instead of using a pre-release identifier.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->