### PR TITLE
new version file script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "build-types": "openapi-typescript https://api-atlas.nomic.ai/v1/api-reference/openapi.json -o ./src/type-gen/openapi.d.ts",
     "build": "tsc",
     "build:watch": "tsc -w",
-    "prepublish": "npm run build",
+    "insert-version": "node -e \"const fs = require('fs'); const pkg = require('./package.json'); fs.writeFileSync('./src/version.ts', 'export const version = \\'' + pkg.version + '\\';');\"",
+    "prepublishOnly": "npm run insert-version && npm run build",
     "precommit": "pretty-quick --staged",
     "prepare": "husky install .husky"
   },

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,1 @@
+export const version = '0.10.1';

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1,5 +1,5 @@
 import { Table, tableFromIPC } from 'apache-arrow';
-import { version } from '../package.json';
+import { version } from './version';
 
 export class AtlasViewer {
   /* 


### PR DESCRIPTION
We want to have the version number available in the code so we can send it in the headers, but we shouldn't be importing it from `package.json`. This script will run before each publish to update the version.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit a1236dfc39f32ccf2c95da474db50e427974817f  | 
|--------|--------|

### Summary:
Added script to generate `version.ts` with current version before publishing and updated `AtlasViewer` to use this version in `User-Agent` header.

**Key points**:
- Have version number available in code without importing from `package.json`.
- Added `insert-version` script in `package.json` to generate `src/version.ts` with current version.
- Updated `prepublishOnly` script in `package.json` to run `insert-version` before building.
- Created `src/version.ts` to export the version number.
- Modified `src/viewer.ts` to import version from `src/version.ts` instead of `package.json`.
- Updated `AtlasViewer.apiCall` method to include `User-Agent` header with SDK version.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->