### PR TITLE
chore: fix type gen command

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "env-cmd --file .env uvu tests -r esbuild-register",
     "test:file": "env-cmd --file .env uvu -r esbuild-register tests",
     "test:embeddings": "npm run test:file -- embedding.test.js",
-    "build-types": "openapi-typescript https://staging-api-atlas.nomic.ai/v1/api-reference/openapi.json -o ./src/type-gen/openapi.ts | prettier ./src/type-gen/openapi.ts --write",
+    "build-types": "openapi-typescript https://staging-api-atlas.nomic.ai/v1/api-reference/openapi.json -o ./src/type-gen/openapi.ts --empty-objects-unknown | npx prettier ./src/type-gen/openapi.ts --write",
     "build": "tsc",
     "build:watch": "tsc -w",
     "insert-version": "node -e \"const fs = require('fs'); const pkg = require('./package.json'); fs.writeFileSync('./src/version.ts', 'export const version = \\'' + pkg.version + '\\';');\"",

--- a/src/type-gen/openapi.ts
+++ b/src/type-gen/openapi.ts
@@ -1155,10 +1155,10 @@ export interface components {
        * Atoms
        * @description The data for each atom, keyed by its atom_id
        */
-      atoms: Record<string, never>;
+      atoms: Record<string, unknown>;
     };
     /** BaseModel */
-    BaseModel: Record<string, never>;
+    BaseModel: Record<string, unknown>;
     /** Body_add_blob_v1_dataset_data_add_blobs_post */
     Body_add_blob_v1_dataset_data_add_blobs_post: {
       /**
@@ -1751,7 +1751,7 @@ export interface components {
        * Hyperparameters
        * @description The hyperparameters this model was trained with.
        */
-      hyperparameters: Record<string, never>;
+      hyperparameters: Record<string, unknown>;
     };
     /** EmbeddingModelInferenceUsage */
     EmbeddingModelInferenceUsage: {
@@ -1900,7 +1900,7 @@ export interface components {
         | components['schemas']['MultiPolygon']
         | components['schemas']['GeometryCollection'];
       /** Properties */
-      properties?: Record<string, never> | components['schemas']['BaseModel'];
+      properties?: Record<string, unknown> | components['schemas']['BaseModel'];
       /** Id */
       id?: string;
       /** Bbox */
@@ -1975,7 +1975,7 @@ export interface components {
        * Datums
        * @description The returned datums without json deserialization.
        */
-      datums: Record<string, never>[];
+      datums: Record<string, unknown>[];
     };
     /** GetProjectionAliasRequest */
     GetProjectionAliasRequest: {
@@ -2393,7 +2393,7 @@ export interface components {
        * Hyperparameters
        * @description The hyperparameters of this index.
        */
-      hyperparameters: Record<string, never>;
+      hyperparameters: Record<string, unknown>;
       /**
        * Atom Strategies
        * @description The phrase strategies of the phrases this embedder is embedding.
@@ -3139,7 +3139,7 @@ export interface components {
        * Datums
        * @description The datums to update
        */
-      datums: Record<string, never>[];
+      datums: Record<string, unknown>[];
       /**
        * Project Id
        * Format: uuid
@@ -3347,7 +3347,7 @@ export interface components {
        * Hyperparameters
        * @description The hyperparameters of this projection.
        */
-      hyperparameters: Record<string, never>;
+      hyperparameters: Record<string, unknown>;
       /**
        * Atom Strategies
        * @description The phrase strategies of the phrases this embedder is embedding.
@@ -3406,7 +3406,7 @@ export interface components {
        * Topic Model Metadatas
        * @description list of topic model metadata
        */
-      topic_model_metadatas: Record<string, never>[];
+      topic_model_metadatas: Record<string, unknown>[];
     };
     /** ProjectsResponse */
     ProjectsResponse: {
@@ -3848,7 +3848,7 @@ export interface components {
        * Results
        * @description A list of topic metadata, including movement information
        */
-      results: Record<string, never>[];
+      results: Record<string, unknown>[];
     };
     /** UpdateInviteRequest */
     UpdateInviteRequest: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 71ff2c6c9ae45fc1826b022f18a015d101f96186  | 
|--------|--------|

### Summary:
The PR updates the `build-types` script to generate more flexible types by changing empty object types from `never` to `unknown` in the generated `src/type-gen/openapi.ts`.

**Key points**:
- Updated `build-types` script in `package.json` to include `--empty-objects-unknown` flag.
- Modified `src/type-gen/openapi.ts` to change `Record<string, never>` to `Record<string, unknown>`.
- Affected components include `atoms`, `BaseModel`, `hyperparameters`, `properties`, `datums`, `topic_model_metadatas`, and `results`.
- Ensures generated types are more flexible for dynamic data structures.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->