### PR TITLE
fix: bad user-agent header removed

### DIFF
--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -98,7 +98,9 @@ export class AtlasViewer {
       }
     }
 
-    headers['User-Agent'] = `ts-nomic/${version}`;
+    // This line caused serious issues with Safari and Firefox.
+    // Disabling but leaving as a marker for future work.
+    // headers['User-Agent'] = `ts-nomic/${version}`;
 
     // Bigints are passed to the API
     // which would break JSON.stringify.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 0917dfad40a914c9d189628c7a19ba73082625d9  | 
|--------|--------|

fix: comment out problematic User-Agent header in AtlasViewer

### Summary:
Commented out `User-Agent` header in `AtlasViewer` to fix issues with Safari and Firefox.

**Key points**:
- **Behavior**:
  - Commented out `User-Agent` header in `apiCall()` method of `AtlasViewer` class in `viewer.ts` due to issues with Safari and Firefox.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->