### PR TITLE
make withLoadedAttributes not bust cache by default

### DIFF
--- a/src/user.ts
+++ b/src/user.ts
@@ -89,8 +89,10 @@ export abstract class BaseAtlasClass<
    *
    */
 
-  async withLoadedAttributes(): Promise<LoadedObject<this, AttributesType>> {
-    await this.fetchAttributes(true);
+  async withLoadedAttributes(
+    bustCache = false
+  ): Promise<LoadedObject<this, AttributesType>> {
+    await this.fetchAttributes(bustCache);
     return this as LoadedObject<this, AttributesType>;
   }
 


### PR DESCRIPTION
As discussed on slack, this call does not need to bust the cache so aggressively.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `withLoadedAttributes` in `BaseAtlasClass` to not bust cache by default, reducing unnecessary cache busting.
> 
>   - **Behavior**:
>     - Change `withLoadedAttributes` in `BaseAtlasClass` to not bust cache by default by setting `bustCache` parameter to `false`.
>     - Affects how attributes are fetched and cached, reducing unnecessary cache busting.
>   - **Functions**:
>     - Modify `withLoadedAttributes()` to accept an optional `bustCache` parameter, defaulting to `false`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fts-nomic&utm_source=github&utm_medium=referral)<sup> for f4887781c563a507bf7989e8982671729a5d9249. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->