### PR TITLE
Add repo and homepage to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "dist"
   ],
   "license": "MIT",
+  "repository": "github:nomic-ai/ts-nomic",
+  "homepage": "https://atlas.nomic.ai",
   "module": "./dist/main.js",
   "types": "./dist/main.d.ts",
   "exports": {


### PR DESCRIPTION
So it shows up on https://www.npmjs.com/package/@nomic-ai/atlas